### PR TITLE
Checksum and list index error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DUMMY: lint test format
 
 format:
-	black .
+	black --preview tests pygt3x
 
 lint:
 	flake8 pygt3x tests

--- a/pygt3x/__init__.py
+++ b/pygt3x/__init__.py
@@ -1,4 +1,5 @@
 """GT3x python module."""
+
 from enum import Enum, unique
 
 

--- a/pygt3x/activity_payload.py
+++ b/pygt3x/activity_payload.py
@@ -1,4 +1,5 @@
 """Binary payload parsing."""
+
 import struct
 
 import numpy as np

--- a/pygt3x/calibration.py
+++ b/pygt3x/calibration.py
@@ -1,4 +1,5 @@
 """Calibrate accelerometer values."""
+
 from typing import Dict
 
 import numpy as np

--- a/pygt3x/components.py
+++ b/pygt3x/components.py
@@ -1,4 +1,5 @@
 """GT3x header structure."""
+
 import io
 import logging
 import struct

--- a/pygt3x/components.py
+++ b/pygt3x/components.py
@@ -1,7 +1,6 @@
 """GT3x header structure."""
 
 import io
-import logging
 import struct
 from dataclasses import dataclass, field
 from typing import Optional, Union

--- a/pygt3x/components.py
+++ b/pygt3x/components.py
@@ -2,7 +2,7 @@
 import io
 import logging
 import struct
-from dataclasses import InitVar, dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Union
 
 import numpy as np
@@ -41,7 +41,7 @@ class Header:
         self.payload_size = payload_size
 
 
-@dataclass(frozen=True)
+@dataclass
 class RawEvent:
     """
     Gt3xRawEvent class.
@@ -58,9 +58,10 @@ class RawEvent:
 
     header: Header
     payload: bytes
-    checksum: InitVar[bytes]
+    checksum: bytes
+    is_checksum_valid: bool = field(init=False)
 
-    def __post_init__(self, checksum: bytes):
+    def __post_init__(self):
         """Verify event's checksum."""
         new_checksum = self.header.separator ^ self.header.event_type
         timestamp = self.header.timestamp.to_bytes(4, "little")
@@ -75,9 +76,10 @@ class RawEvent:
             np.frombuffer(self.payload, dtype=np.uint8), initial=new_checksum
         )
         new_checksum = int(~new_checksum & 0xFF)
-        if new_checksum.to_bytes(1, "little") != checksum:
-            logging.warning("Corrupted event at %s.", self.header.timestamp)
-            raise ValueError("Event checksum does not match.")
+        self.is_checksum_valid = new_checksum.to_bytes(1, "little") == self.checksum
+        # if new_checksum.to_bytes(1, "little") != checksum:
+        #     logging.warning("Corrupted event at %s.", self.header.timestamp)
+        #     raise ValueError("Event checksum does not match.")
 
 
 @dataclass

--- a/pygt3x/components.py
+++ b/pygt3x/components.py
@@ -78,9 +78,6 @@ class RawEvent:
         )
         new_checksum = int(~new_checksum & 0xFF)
         self.is_checksum_valid = new_checksum.to_bytes(1, "little") == self.checksum
-        # if new_checksum.to_bytes(1, "little") != checksum:
-        #     logging.warning("Corrupted event at %s.", self.header.timestamp)
-        #     raise ValueError("Event checksum does not match.")
 
 
 @dataclass

--- a/pygt3x/reader.py
+++ b/pygt3x/reader.py
@@ -312,7 +312,7 @@ class FileReader:
             duplicates_removed = acceleration[counts > 1]
             if duplicates_removed.size > 0:
                 logger.warning(
-                    "%s duplicate accelerometer samples removed.",
+                    "%s duplicate accelerometer records removed.",
                     duplicates_removed.shape[0],
                 )
                 for d in duplicates_removed:

--- a/pygt3x/reader.py
+++ b/pygt3x/reader.py
@@ -20,6 +20,7 @@ from pygt3x.activity_payload import (
 from pygt3x.calibration import CalibrationV2Service
 from pygt3x.components import Header, Info, RawEvent
 
+
 class FileReader:
     """Read GT3X/AGDC files.
 
@@ -144,7 +145,9 @@ class FileReader:
         for evt in self.read_events(num_rows):
 
             if not evt.is_checksum_valid:
-                logging.warning(f"Event checksum does not match at {evt.header.timestamp}.")
+                logging.warning(
+                    f"Event checksum does not match at {evt.header.timestamp}."
+                )
                 continue
 
             try:
@@ -302,21 +305,27 @@ class FileReader:
 
         # Make sure each second appears sample rate times
         # 1) check for and remove identical samples
-        self.acceleration, counts = np.unique(self.acceleration, axis=0, return_counts=True)
+        self.acceleration, counts = np.unique(
+            self.acceleration, axis=0, return_counts=True
+        )
         duplicates_removed = self.acceleration[counts > 1]
         if duplicates_removed.size > 0:
-            self.logger.warning(f"{duplicates_removed.shape[0]} duplicate accelerometer samples removed.")
+            self.logger.warning(
+                f"{duplicates_removed.shape[0]} duplicate accelerometer samples removed."
+            )
             for d in duplicates_removed:
                 self.logger.debug(f"Duplicate sample removed: {d.tolist()}")
 
         # 2) in remaining data check for seconds that do not have appropriate number of samples
         counter = Counter(self.acceleration[:, 0].astype(int))
-        wrong_freq_cases = [(k, v) for k, v in counter.items() if v != self.info.sample_rate]
-        #if len(wrong_freq_cases) > 0:
+        wrong_freq_cases = [
+            (k, v) for k, v in counter.items() if v != self.info.sample_rate
+        ]
+        # if len(wrong_freq_cases) > 0:
         for w in wrong_freq_cases:
-            self.logger.warning(f"Timestamp (second) {w[0]} has {w[1]} samples instead of {self.info.sample_rate}.")
-
-
+            self.logger.warning(
+                f"Timestamp (second) {w[0]} has {w[1]} samples instead of {self.info.sample_rate}."
+            )
 
     def calibrate_acceleration(self):
         """Calibrates acceleration samples."""

--- a/pygt3x/reader.py
+++ b/pygt3x/reader.py
@@ -145,7 +145,7 @@ class FileReader:
         for evt in self.read_events(num_rows):
 
             if not evt.is_checksum_valid:
-                logging.warning(
+                self.logger.warning(
                     f"Event checksum does not match at {evt.header.timestamp}."
                 )
                 continue
@@ -304,19 +304,6 @@ class FileReader:
             self.temperature = np.concatenate(temperature)
 
         # Make sure each second appears sample rate times
-        # 1) check for and remove identical samples
-        self.acceleration, counts = np.unique(
-            self.acceleration, axis=0, return_counts=True
-        )
-        duplicates_removed = self.acceleration[counts > 1]
-        if duplicates_removed.size > 0:
-            self.logger.warning(
-                f"{duplicates_removed.shape[0]} duplicate accelerometer samples removed."
-            )
-            for d in duplicates_removed:
-                self.logger.debug(f"Duplicate sample removed: {d.tolist()}")
-
-        # 2) in remaining data check for seconds that do not have appropriate number of samples
         counter = Counter(self.acceleration[:, 0].astype(int))
         wrong_freq_cases = [
             (k, v) for k, v in counter.items() if v != self.info.sample_rate

--- a/pygt3x/reader.py
+++ b/pygt3x/reader.py
@@ -316,7 +316,9 @@ class FileReader:
                     duplicates_removed.shape[0],
                 )
                 for d in duplicates_removed:
-                    logger.debug("Duplicate accelerometer record removed: %s", d.tolist())
+                    logger.debug(
+                        "Duplicate accelerometer record removed: %s", d.tolist()
+                    )
 
         if len(acceleration) > 0:
             self.acceleration = np.concatenate(acceleration)

--- a/pygt3x/reader.py
+++ b/pygt3x/reader.py
@@ -316,7 +316,7 @@ class FileReader:
                     duplicates_removed.shape[0],
                 )
                 for d in duplicates_removed:
-                    logger.debug("Duplicate sample removed: %s", d.tolist())
+                    logger.debug("Duplicate accelerometer record removed: %s", d.tolist())
 
         if len(acceleration) > 0:
             self.acceleration = np.concatenate(acceleration)

--- a/pygt3x/reader.py
+++ b/pygt3x/reader.py
@@ -439,24 +439,3 @@ class LogReader:
             return None
         raw_event = RawEvent(header, payload_bytes, checksum)
         return raw_event
-
-if __name__ == "__main__":
-
-    from pathlib import Path
-    from datetime import datetime
-
-    logging.basicConfig(level=logging.DEBUG)
-
-    #gt3x_path = Path("W:/hr_device_comp/ActiGraph/TAS1H20200138 (2024-02-02).gt3x")
-    #gt3x_path = Path("W:/MacM3/MacM3_Samples_Waterloo/MacM3-31_4M/MacM3-31_4M.gt3x")
-    gt3x_path = Path("X:/MacM3/Actigraph Problems/CorruptedEvent/MacM3-242_B.gt3x")
-
-
-    start_time = datetime.now()
-    # Read raw data and calibrate, then export to pandas data frame
-    with FileReader(gt3x_path) as reader:
-        was_idle_sleep_mode_used = reader.idle_sleep_mode_activated
-        accel = reader.to_pandas()
-        temperature = reader.temperature_to_pandas()
-
-    print(f"Duration: {datetime.now() - start_time}")

--- a/pygt3x/reader.py
+++ b/pygt3x/reader.py
@@ -311,7 +311,8 @@ class FileReader:
         # if len(wrong_freq_cases) > 0:
         for w in wrong_freq_cases:
             self.logger.warning(
-                f"Timestamp (second) {w[0]} has {w[1]} samples instead of {self.info.sample_rate}."
+                f"Timestamp (second) {w[0]} has {w[1]} samples"
+                f" instead of {self.info.sample_rate}."
             )
 
     def calibrate_acceleration(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygt3x"
-version = "0.5.5"
+version = "0.6.0"
 description = "Python module for reading GT3X/AGDC file format data"
 authors = ["Mark Fogle <mark.fogle@theactigraph.com>"]
 maintainers = ["Ali Neishabouri <ali.neishabouri@theactigraph.com>"]
@@ -20,6 +20,7 @@ flake8 = "^6.0.0"
 pytest-cov = "^4.0.0"
 pydocstyle = "^6.1.1"
 types-setuptools = "^65.7.0.3"
+flake8-logging = "^1.6.0"
 
 [[tool.mypy.overrides]]
 module = ["pandas"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygt3x"
-version = "0.5.2"
+version = "0.5.5"
 description = "Python module for reading GT3X/AGDC file format data"
 authors = ["Mark Fogle <mark.fogle@theactigraph.com>"]
 maintainers = ["Ali Neishabouri <ali.neishabouri@theactigraph.com>"]


### PR DESCRIPTION


Fixed 3 errors that occured while reading gt3x data:

WARNING:root:Corrupted event at 1664824978

Issue:

    FileReader._get_data_default() iterates over records in log.bin by calling FileReader.read_events() which yields RawEvent dataclass returned from LogReader.read_event()
    LogReader.read_event() attempts to read a single record and return it as RawEvent dataclass or if no events left returns None to indicate EOF
    dataclass RawEvent.__post_init__() validates checksum and raises a ValueError if checksum fails
    LogReader.read_event() captures this ValueError and returns None in place of RawEvent dataclass
    So, LogReader.read_event() could return None if a checksum fails or if EOF
    FileReader.read_events() interprets this None from LogReader.read_event() as EOF and stops yielding events to FileReader._get_data_default()

Fix:

    RawEvent dataclass now has is_checksum_valid attribute that is set by RawEvent.post_init()after checksum validation
    LogReader.read_event() no longer captures ValueError and returns None, instead it returns the RawEvent with is_checksum_valid attribute
    No changes to FileReader.read_events() - None from LogReader.read_event() only occurs if EOF and is interpreted as such
    FileReader._get_data_default() assesses RawEvent.is_checksum_valid for each record before parsing data
    When a checksum fails:
        RawEvent.__post_init__() sets is_checksum_valid to False instead of raising an error and returns RawEvent dataclass to LogReader.read_event()
        LogReader.read_event() returns RawEvent with is_checksum_valid attribute to FileReader.read_events() which yields it to FileReader._get_data_default()
        FileReader._get_data_default() reads RawEvent.is_checksum_valid == False and logs a warning before ignoring the record and continuing to the next

WARNING:main:Wrong freq cases: [(1664739498, 100)]

Issue:

    Activty log record (type = 0) at timestamp 1664739498 is written twice
    Pygt3x reader simply writes a warning to the file indicating some timestamp seconds (int of timestamp) occur more often than the sample rate
        Modified this warning to display the timestamp for debugging
    Confirmed by reading raw log records, which had this log record written twice
        This record is the first activity record written after exiting ISM

Fix:
    kept check for samples in each second after exact duplicate samples removed for redundancy in case a different issue is meant to be caught by this check

List indexed by float

Issue:

    FileReader._get_data_default() calculates dt as time in seconds elapsed from last accelerometer record timestamp to current record timestamp
    The timestamp of the last accelerometer record is calculated from the first timestamp in the series of sample timestamps from the last accelerometer record, which is a float ending in .0
    So dt is calculated by subtracting a float ending in .0 from an integer resulting in dt being a float

Fix:

    use int(dt) when indexing acceleration list

