### PR TITLE
Adding heart rate functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ with FileReader("FILENAME") as reader:
     df = reader.temperature_to_pandas()
     print(df.head(5))
 ```
+
+If your GT3X file contains Bluetooth heart rate data, you can read it using:
+
+```python
+from pygt3x.reader import FileReader
+
+with FileReader("FILENAME") as reader:
+    df = reader.hr_to_pandas()
+    print(df.head(5))
+```


### PR DESCRIPTION
Some Actigraph devices (e.g. wGT3X-BT) can be paired with a heart rate monitor using Bluetooth. While the heart rate data is stored inside the .gt3x files, there is currently (as far as I know) no open-source approach for retrieving the raw heart rate data. These changes are adding HR functionality to the pygt3x module.

It generally seems like there are a few missing values within the 1Hz raw heart rate data. However, that might just be specific to the single device used for generating some test data. Further post-processing of the sampled HR data would need to be performed. But that is likely outside the scope of this module. I have compared the HR output against output from ActiLife - based on 10s epochs.

![image](https://github.com/user-attachments/assets/9f23c9c3-0d34-4332-9b88-4ed1a7b89e29)